### PR TITLE
 Add JSONManager for saving and loading operations history to/from JSON

### DIFF
--- a/src/files.py
+++ b/src/files.py
@@ -1,0 +1,18 @@
+import json
+
+
+class JSONManager:
+    @staticmethod
+    def save_to_json(data: list, filename: str):
+        with open(filename, 'w') as file:
+            serialized_data = [record.to_dict() for record in data]
+            json.dump(serialized_data, file, indent=4, ensure_ascii=False)
+        print(f"Data saved to {filename}")
+
+    @staticmethod
+    def load_from_json(filename: str) -> list or str:
+        with open(filename, 'r') as file:
+            serialized_data = json.load(file)
+
+        return serialized_data
+


### PR DESCRIPTION
## Description
This pull request introduces a `JSONManager` class to handle saving and loading data (e.g., operations history) to and from JSON files. The `JSONManager` class ensures that data can be serialized and deserialized for persistent storage of Caesar Cipher operations.

## Changes
- Added `JSONManager` class with two static methods:
  - `save_to_json(data: list, filename: str)`:
    - Serializes a list of data into a JSON file.
    - Saves the list of records (as dictionaries) to the specified file.
    - Ensures proper indentation and support for Polish characters (`ensure_ascii=False`).
  - `load_from_json(filename: str) -> list`:
    - Loads serialized data from a specified JSON file.
    - Returns the list of records for further use.
  
## Features
- **Save to JSON**: Serialize a list of data (history of operations) and save it to a specified JSON file.
- **Load from JSON**: Load data from a JSON file, allowing users to restore the saved history.

## How to Test
1. Create a sample list of records (or use the existing operations history in your project).
   ```python
   data = [{"operation": "encrypt", "text": "example", "shift": 3}]
